### PR TITLE
Create POCTIFY AI Desk monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+backend/uploads/*
+!backend/uploads/.gitkeep
+backend/dist/*
+!backend/dist/.gitkeep
+node_modules/
+frontend/node_modules/
+__pycache__/
+*.pyc
+.env
+!/backend/.env
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# POCTIFY AI Desk
+
+Monorepo containing FastAPI backend and React frontend with Vite and Tailwind CSS.

--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,2 @@
+# Example environment variables
+OPENAI_API_KEY=

--- a/backend/ai_utils.py
+++ b/backend/ai_utils.py
@@ -1,0 +1,6 @@
+"""Placeholder for future AI integrations (e.g., OpenAI)."""
+
+
+def get_ai_response(question: str) -> str:
+    """Return a placeholder response for a question."""
+    return f"This is a placeholder response to: {question}"

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,49 @@
+import os
+from fastapi import FastAPI, Request, UploadFile, File
+from fastapi.responses import JSONResponse, FileResponse, HTMLResponse
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from starlette.responses import RedirectResponse
+from dotenv import load_dotenv
+
+from routes import ask, upload, docs
+
+load_dotenv(os.path.join(os.path.dirname(__file__), '.env'))
+
+app = FastAPI()
+
+origins = [
+    "https://ai.poctify.com",
+    "http://localhost:5173",
+]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(ask.router, prefix="/api")
+app.include_router(upload.router, prefix="/api")
+app.include_router(docs.router, prefix="/api")
+
+# Health check
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok"}
+
+# Serve static files
+app.mount("/", StaticFiles(directory="dist", html=True), name="static")
+
+# Fallback to index.html for client-side routing
+@app.exception_handler(404)
+async def custom_404_handler(request: Request, exc):
+    index_path = os.path.join("dist", "index.html")
+    if os.path.exists(index_path):
+        return HTMLResponse(open(index_path).read())
+    return JSONResponse(status_code=404, content={"detail": "Not Found"})
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+python-multipart
+python-dotenv

--- a/backend/routes/ask.py
+++ b/backend/routes/ask.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from ..ai_utils import get_ai_response
+
+router = APIRouter()
+
+class AskRequest(BaseModel):
+    question: str
+
+@router.post("/ask")
+async def ask_question(req: AskRequest):
+    answer = get_ai_response(req.question)
+    return {"answer": answer}

--- a/backend/routes/docs.py
+++ b/backend/routes/docs.py
@@ -1,0 +1,10 @@
+import os
+from fastapi import APIRouter
+
+router = APIRouter()
+UPLOAD_DIR = os.path.join(os.path.dirname(__file__), "..", "uploads")
+
+@router.get("/docs")
+async def list_docs():
+    files = [f for f in os.listdir(UPLOAD_DIR) if not f.startswith('.')]
+    return {"files": files}

--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -1,0 +1,13 @@
+import os
+from fastapi import APIRouter, UploadFile, File
+
+router = APIRouter()
+UPLOAD_DIR = os.path.join(os.path.dirname(__file__), "..", "uploads")
+
+@router.post("/upload")
+async def upload_file(file: UploadFile = File(...)):
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    file_location = os.path.join(UPLOAD_DIR, file.filename)
+    with open(file_location, "wb") as buffer:
+        buffer.write(await file.read())
+    return {"filename": file.filename}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  backend:
+    build: ./backend
+    command: uvicorn main:app --reload --host 0.0.0.0 --port 8000
+    volumes:
+      - ./backend:/app
+    ports:
+      - "8000:8000"
+  frontend:
+    build: ./frontend
+    command: npm run dev
+    volumes:
+      - ./frontend:/app
+    ports:
+      - "5173:5173"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "poctify-ai-desk",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.17.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.2",
+    "vite": "^4.4.9"
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>POCTIFY AI Desk</title>
+  </head>
+  <body class="bg-navy text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Outlet } from 'react-router-dom'
+import Navbar from './components/Navbar'
+
+const App = () => (
+  <div className="min-h-screen bg-navy text-white">
+    <Navbar />
+    <main className="p-4">
+      <Outlet />
+    </main>
+  </div>
+)
+
+export default App

--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react'
+import axios from 'axios'
+
+const ChatBox = () => {
+  const [question, setQuestion] = useState('')
+  const [answer, setAnswer] = useState('')
+
+  const submit = async () => {
+    const res = await axios.post('/api/ask', { question })
+    setAnswer(res.data.answer)
+  }
+
+  return (
+    <div>
+      <textarea
+        className="w-full p-2 text-black"
+        value={question}
+        onChange={e => setQuestion(e.target.value)}
+      />
+      <button className="bg-teal text-white p-2 mt-2" onClick={submit}>
+        Ask
+      </button>
+      {answer && (
+        <div className="mt-4 p-2 bg-gray-800">{answer}</div>
+      )}
+    </div>
+  )
+}
+
+export default ChatBox

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+const Navbar = () => (
+  <nav className="bg-teal p-4 flex gap-4">
+    <Link to="/" className="font-bold">POCTIFY AI Desk</Link>
+    <Link to="/desk">Desk</Link>
+    <Link to="/docs">Docs</Link>
+    <Link to="/upload">Upload</Link>
+  </nav>
+)
+
+export default Navbar

--- a/frontend/src/components/SOPList.jsx
+++ b/frontend/src/components/SOPList.jsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from 'react'
+import axios from 'axios'
+
+const SOPList = () => {
+  const [files, setFiles] = useState([])
+
+  useEffect(() => {
+    axios.get('/api/docs').then(res => setFiles(res.data.files))
+  }, [])
+
+  return (
+    <ul className="list-disc ml-4">
+      {files.map(f => (
+        <li key={f}>{f}</li>
+      ))}
+    </ul>
+  )
+}
+
+export default SOPList

--- a/frontend/src/components/UploadForm.jsx
+++ b/frontend/src/components/UploadForm.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react'
+import axios from 'axios'
+
+const UploadForm = () => {
+  const [file, setFile] = useState(null)
+
+  const submit = async e => {
+    e.preventDefault()
+    if (!file) return
+    const formData = new FormData()
+    formData.append('file', file)
+    await axios.post('/api/upload', formData)
+    alert('Uploaded')
+  }
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-4">
+      <input type="file" onChange={e => setFile(e.target.files[0])} />
+      <button className="bg-teal text-white p-2" type="submit">Upload</button>
+    </form>
+  )
+}
+
+export default UploadForm

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import App from './App'
+import Home from './pages/Home'
+import Desk from './pages/Desk'
+import Docs from './pages/Docs'
+import Upload from './pages/Upload'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />}> 
+          <Route index element={<Home />} />
+          <Route path="desk" element={<Desk />} />
+          <Route path="docs" element={<Docs />} />
+          <Route path="upload" element={<Upload />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  </React.StrictMode>
+)

--- a/frontend/src/pages/Desk.jsx
+++ b/frontend/src/pages/Desk.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import ChatBox from '../components/ChatBox'
+
+const Desk = () => (
+  <div>
+    <h2 className="text-xl mb-2">Ask the AI Desk</h2>
+    <ChatBox />
+  </div>
+)
+
+export default Desk

--- a/frontend/src/pages/Docs.jsx
+++ b/frontend/src/pages/Docs.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import SOPList from '../components/SOPList'
+
+const Docs = () => (
+  <div>
+    <h2 className="text-xl mb-2">Available Documents</h2>
+    <SOPList />
+  </div>
+)
+
+export default Docs

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+const Home = () => (
+  <div>
+    <h1 className="text-2xl mb-4">POCTIFY AI Desk</h1>
+    <p>Streamline point-of-care testing with AI assistance.</p>
+  </div>
+)
+
+export default Home

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import UploadForm from '../components/UploadForm'
+
+const Upload = () => (
+  <div>
+    <h2 className="text-xl mb-2">Upload Document</h2>
+    <UploadForm />
+  </div>
+)
+
+export default Upload

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx}'
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        navy: '#0a1f44',
+        teal: '#1bc5bd',
+      }
+    }
+  },
+  plugins: [],
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  },
+  build: {
+    outDir: 'dist'
+  }
+})

--- a/scripts/build_frontend.sh
+++ b/scripts/build_frontend.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/.."
+cd frontend
+npm install
+npm run build
+cd ..
+rm -rf backend/dist
+mkdir -p backend/dist
+cp -r frontend/dist/* backend/dist/


### PR DESCRIPTION
## Summary
- add monorepo structure for FastAPI backend and React frontend
- implement placeholder API endpoints and frontend pages
- include build script to copy frontend build to backend

## Testing
- `python3 -m pip install -r backend/requirements.txt` *(fails: cannot access pypi)*
- `npm install` in `frontend` *(fails: cannot access registry)*

------
https://chatgpt.com/codex/tasks/task_e_686c1526e68c832285c030638b2ba258